### PR TITLE
✨ Aggiunta endpoint /transcribe per speech-to-text lato server

### DIFF
--- a/src/elia/app.py
+++ b/src/elia/app.py
@@ -1,5 +1,14 @@
-from server import create_app
+import os
+import warnings
+
+# Disabilita warnings prima di qualsiasi import
+os.environ['KMP_DUPLICATE_LIB_OK'] = 'TRUE'
+os.environ['PYTHONWARNINGS'] = 'ignore'
+warnings.filterwarnings("ignore")
+
+
+from elia.server import create_app
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=app.config["PORT"], debug=app.config["DEBUG"])
+    app.run(host="127.0.0.1", port=app.config["PORT"], debug=app.config["DEBUG"])

--- a/src/elia/app.py
+++ b/src/elia/app.py
@@ -1,12 +1,6 @@
 import os
 import warnings
 
-# Disabilita warnings prima di qualsiasi import
-os.environ['KMP_DUPLICATE_LIB_OK'] = 'TRUE'
-os.environ['PYTHONWARNINGS'] = 'ignore'
-warnings.filterwarnings("ignore")
-
-
 from elia.server import create_app
 app = create_app()
 

--- a/src/elia/client/events.py
+++ b/src/elia/client/events.py
@@ -1,8 +1,39 @@
+import requests
 from elia.client.EventEmitter import EventEmitter
+from elia.client.recorder import record_until_silence
+import io
+from elia.config import Config
+import requests
+import os
+import datetime
 
 event_emitter = EventEmitter()
 
 def on_wake_word_detected(**kwargs):
-    print("✅ Wake word trovata: 'Ehi Elia' dentro evento")
+    print("✅ Wake word trovata: 'Ehi Elia' → inizio registrazione")
+    wav_bytes = record_until_silence()
+
+    try:
+        files = {"audio": ("audio.wav", io.BytesIO(wav_bytes), "audio/wav")}
+        r = requests.post(Config.ENDPOINT_TRANSCRIBE, files=files, timeout=60)
+        r.raise_for_status()
+        text = (r.json().get("text", "") or "").strip()
+        
+        os.makedirs("trascripts", exist_ok=True)
+        name = datetime.datetime.now().strftime("%Y%m%d_%H%M%S") + ".txt"
+        with open(f"trascripts/{name}", "w") as f:
+            f.write(text)
+        print("✅ Trascrizione salvata:", name if text else "Nessun testo riconosciuto")
+        
+    except requests.exceptions.ConnectionError:
+        print("❌ Errore: Impossibile connettersi al server di trascrizione")
+    except requests.exceptions.Timeout:
+        print("❌ Errore: Timeout della richiesta al server di trascrizione")
+    except requests.exceptions.HTTPError as e:
+        print(f"❌ Errore HTTP: {e.response.status_code} - {e.response.reason}")
+    except requests.exceptions.RequestException as e:
+        print(f"❌ Errore nella richiesta: {str(e)}")
+    except Exception as e:
+        print(f"❌ Errore imprevisto durante la trascrizione: {str(e)}")
 
 event_emitter.on(event_emitter.WORD_DETECTED, on_wake_word_detected)

--- a/src/elia/client/recorder.py
+++ b/src/elia/client/recorder.py
@@ -1,0 +1,36 @@
+import io, wave
+import sounddevice as sd
+import webrtcvad
+
+def record_until_silence(samplerate=16000, frame_ms=30, max_silence_ms=800):
+    """Registra finché c'è voce e si ferma dopo un certo silenzio."""
+    
+    vad = webrtcvad.Vad(2)  # livello di aggressività del VAD (0-3)
+    frame_bytes = int(samplerate * frame_ms / 1000) * 2  # byte per frame (mono int16)
+    silence_frames_needed = int(max_silence_ms / frame_ms)
+
+    collected = []     # blocchi audio con voce
+    silent_count = 0   # frame consecutivi di silenzio
+
+    print("🎙️ Parla pure… mi fermo quando c'è silenzio")
+    with sd.RawInputStream(samplerate=samplerate, channels=1, dtype="int16") as stream:
+        while True:
+            data, _ = stream.read(frame_bytes // 2)
+            b = bytes(data)
+            if vad.is_speech(b, samplerate):
+                collected.append(b)
+                silent_count = 0
+            else:
+                silent_count += 1
+                if silent_count >= silence_frames_needed:
+                    break
+
+    # converte in WAV in memoria
+    pcm = b"".join(collected)
+    bio = io.BytesIO()
+    with wave.open(bio, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(samplerate)
+        wf.writeframes(pcm)
+    return bio.getvalue()

--- a/src/elia/config.py
+++ b/src/elia/config.py
@@ -10,3 +10,5 @@ class Config:
     PICOVOICE_WORD = os.getenv("PICOVOICE_WORD")
     PICOVOICE_PARAMS = os.getenv("PICOVOICE_PARAMS")
     AUDIO_DEVICE_INDEX = int(os.getenv("AUDIO_DEVICE_INDEX", 0))
+    ENDPOINT_TRANSCRIBE = os.getenv("ENDPOINT_TRANSCRIBE", "http://localhost:5000/transcribe")
+    WHISPER_MODEL = os.getenv("FWHISPER_MODEL", "small")  # Modello ASR Faster-Whisper

--- a/src/elia/server/__init__.py
+++ b/src/elia/server/__init__.py
@@ -1,11 +1,13 @@
 from flask import Flask
 from elia.config import Config
+from elia.server.routes.health import bp as health_bp
+from elia.server.routes.transcribe import bp as transcribe_bp
 
 def create_app():
     app = Flask(__name__, static_folder="server/static", static_url_path="/static")
     app.config.from_object(Config)
 
     # Blueprints
-    from .routes.health import bp as health_bp
-    app.register_blueprint(health_bp, url_prefix="/_")
+    app.register_blueprint(transcribe_bp, url_prefix="")
+    app.register_blueprint(health_bp, url_prefix="")
     return app

--- a/src/elia/server/routes/transcribe.py
+++ b/src/elia/server/routes/transcribe.py
@@ -1,0 +1,43 @@
+from flask import Blueprint, request, jsonify, current_app
+import tempfile, os, datetime
+from elia.server.services.asr import transcribe_wav
+
+# Disabilita warnings prima di qualsiasi import
+os.environ['KMP_DUPLICATE_LIB_OK'] = 'TRUE'
+
+bp = Blueprint("transcribe", __name__)
+
+def _transcripts_dir() -> str:
+    # cartella configurabile via ENV/Config, fallback a "data/transcripts"
+    base = getattr(current_app.config, "TRANSCRIPTS_DIR", None) or "data/transcripts"
+    os.makedirs(base, exist_ok=True)
+    return base
+
+@bp.post("/transcribe")
+def transcribe_endpoint():
+    if "audio" not in request.files:
+        return jsonify(success=False, error="manca il file 'audio'"), 400
+
+    f = request.files["audio"]
+    if not f.filename:
+        return jsonify(success=False, error="nome file vuoto"), 400
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    f.save(tmp.name)
+    try:
+        res = transcribe_wav(tmp.name)   # {"text":..., "duration":...}
+        text, duration = res.get("text", ""), res.get("duration")
+
+        # salva SOLO lato server
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_dir = _transcripts_dir()
+        out_path = os.path.join(out_dir, f"{ts}.txt")
+        with open(out_path, "w", encoding="utf-8") as out:
+            out.write(text.strip() + "\n")
+
+        return jsonify(success=True, id=ts, duration=duration)
+    except Exception as e:
+        return jsonify(success=False, error=str(e)), 500
+    finally:
+        try: os.remove(tmp.name)
+        except: pass

--- a/src/elia/server/services/asr.py
+++ b/src/elia/server/services/asr.py
@@ -1,0 +1,14 @@
+# trascrizione con faster-whisper (italiano)
+from faster_whisper import WhisperModel
+from elia.config import Config
+
+_model = WhisperModel(
+    Config.WHISPER_MODEL or "small",
+    device="cuda",
+    compute_type="auto"
+)
+
+def transcribe_wav(path_wav: str) -> dict:
+    segments, info = _model.transcribe(path_wav, language="it")
+    text = " ".join(s.text.strip() for s in segments).strip()
+    return {"text": text, "duration": info.duration}


### PR DESCRIPTION
## feat(api): aggiunto endpoint `/transcribe` per speech-to-text lato server

### Descrizione
- Creato nuovo endpoint REST `/transcribe`.
- L’audio ora viene inviato dal client al server per l’elaborazione.
- L’operazione di speech-to-text viene eseguita direttamente lato server, centralizzando la logica ed evitando carico sul client.
