### PR TITLE
"Miglioramenti al flusso di trascrizione audio: confidenza ASR, gestione client-server e configurazione"

### DIFF
--- a/src/elia/client/events.py
+++ b/src/elia/client/events.py
@@ -1,35 +1,37 @@
 import requests
+import io
 from elia.client.EventEmitter import EventEmitter
 from elia.client.recorder import record_until_silence
-import io
 from elia.config import Config
+from elia.client.request_handler import send_audio_and_get_result
+
+
 event_emitter = EventEmitter()
 
 def on_wake_word_detected(**kwargs):
+    """Si attiva quando viene rilevata la wake word."""
     print("✅ Wake word trovata: 'Ehi Elia' → inizio registrazione")
-    wav_bytes = record_until_silence()
+    while True:
+        wav_bytes = record_until_silence()
+        print("🎙️ Registrazione completata, invio al server per trascrizione...")
+        result = send_audio_and_get_result(wav_bytes)
 
-    try:
-        files = {"audio": ("audio.wav", io.BytesIO(wav_bytes), "audio/wav")}
-        r = requests.post(Config.ENDPOINT_TRANSCRIBE, files=files, timeout=60)
-        r.raise_for_status()
-        result = r.json()
-
-        if result.get("success"):
-            print("✅ Messaggio inviato correttamente")
-        else:
+        if not result.get("success"):
             print("❌ Errore nella trascrizione:", result.get("error", "motivo sconosciuto"))
+            return
 
-    except requests.exceptions.ConnectionError:
-        print("❌ Errore: Impossibile connettersi al server di trascrizione")
-    except requests.exceptions.Timeout:
-        print("❌ Errore: Timeout della richiesta al server di trascrizione")
-    except requests.exceptions.HTTPError as e:
-        print(f"❌ Errore HTTP: {e.response.status_code} - {e.response.reason}")
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Errore nella richiesta: {str(e)}")
-    except Exception as e:
-        print(f"❌ Errore imprevisto durante la trascrizione: {str(e)}")
+        status = result.get("status", "ok")
+        confidence = result.get("confidence")
 
+        if status == "ok":
+            print("✅ Trascrizione OK")
+            if confidence is not None:
+                print(f"   Confidenza: {confidence}")
+            return
+
+        if status == "clarify":
+            print(f"❓ {result.get('message', 'Non sono sicuro di aver capito perfettamente.')}")
+            print("🎙️  Per favore ripeti: sto registrando di nuovo…")
+            continue
 
 event_emitter.on(event_emitter.WORD_DETECTED, on_wake_word_detected)

--- a/src/elia/client/request_handler.py
+++ b/src/elia/client/request_handler.py
@@ -1,0 +1,12 @@
+import io
+import requests
+from elia.config import Config
+from elia.client.recorder import record_until_silence
+
+def send_audio_and_get_result(wav_bytes: bytes, timeout=60) -> dict:
+    """Invia l'audio al server di trascrizione e ritorna il risultato JSON."""
+    files = {"audio": ("audio.wav", io.BytesIO(wav_bytes), "audio/wav")}
+    r = requests.post(Config.ENDPOINT_TRANSCRIBE, files=files, timeout=timeout)
+    r.raise_for_status()
+    return r.json()
+

--- a/src/elia/client/wake.py
+++ b/src/elia/client/wake.py
@@ -1,11 +1,9 @@
 import os
-from dotenv import load_dotenv
 import pvporcupine
 from pvrecorder import PvRecorder
 from elia.config import Config
 from elia.client.events import event_emitter
 
-load_dotenv()
 ACCESS_KEY = Config.PICOVOICE_KEY
 KEYWORD_PATH = Config.PICOVOICE_WORD  # .ppn della keyword "Ehi Elia"
 

--- a/src/elia/config.py
+++ b/src/elia/config.py
@@ -14,3 +14,5 @@ class Config:
     AUDIO_DEVICE_INDEX = int(os.getenv("AUDIO_DEVICE_INDEX", 0))
     ENDPOINT_TRANSCRIBE = os.getenv("ENDPOINT_TRANSCRIBE", "http://localhost:5000/transcribe")
     WHISPER_MODEL = os.getenv("FWHISPER_MODEL", "small")  # Modello ASR Faster-Whisper
+    ASR_CONF_THRESHOLD = float(os.getenv("ASR_CONF_THRESHOLD", 0.60))
+    ASR_MIN_WORDS = int(os.getenv("ASR_MIN_WORDS", 3))

--- a/src/elia/server/services/asr.py
+++ b/src/elia/server/services/asr.py
@@ -4,9 +4,13 @@ from faster_whisper import WhisperModel
 from elia.config import Config
 import torch
 from statistics import mean
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
-print(f"Using device: {device}")
+logger.info(f"Using device: {device}")
 
 _model = WhisperModel(
     Config.WHISPER_MODEL or "medium",

--- a/src/elia/server/services/asr.py
+++ b/src/elia/server/services/asr.py
@@ -1,18 +1,83 @@
 # trascrizione con faster-whisper (italiano)
+import math
 from faster_whisper import WhisperModel
 from elia.config import Config
 import torch
+from statistics import mean
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
+print(f"Using device: {device}")
+
 _model = WhisperModel(
-    Config.WHISPER_MODEL or "small",
+    Config.WHISPER_MODEL or "medium",
     device=device,
     compute_type="auto"
 )
 
 print("Faster Whisper model initialized")
 
+#Funzione di Trascrizione
 def transcribe_wav(path_wav: str) -> dict:
-    segments, info = _model.transcribe(path_wav, language="it")
-    text = " ".join(s.text.strip() for s in segments).strip()
-    return {"text": text, "duration": info.duration}
+    
+    segments, info = _model.transcribe(
+        path_wav,
+        language="it",
+        beam_size=5,
+        vad_filter=True,
+        word_timestamps=True  # parola-per-parola
+    )
+
+    segs = list(segments)
+    text = " ".join(s.text.strip() for s in segs).strip()
+
+    # Calcola confidenza
+    conf_words = _compute_confidence(segs)
+    lang_prob = getattr(info, "language_probability", None)
+
+    if isinstance(lang_prob, float):
+        confidence = 0.8 * conf_words + 0.2 * lang_prob
+    else:
+        confidence = conf_words
+
+    return {
+        "text": text,
+        "duration": getattr(info, "duration", None),
+        "confidence": float(confidence)
+    }
+
+
+# Normalizzazione valore di soglia
+def _sigmoid(x: float) -> float:
+    x = max(min(x, 10.0), -10.0)
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+#Calcolo della confidenza
+def _compute_confidence(segments) -> float:
+
+    word_probs, avg_logprobs, no_speech = [], [], []
+
+    for seg in segments:
+        # 1) parola-per-parola (migliore)
+        if getattr(seg, "words", None):
+            for w in seg.words:
+                p = getattr(w, "probability", None)
+                if p is not None:
+                    word_probs.append(float(p))
+        # 2) fallback: media degli avg_logprob dei segmenti
+        if getattr(seg, "avg_logprob", None) is not None:
+            avg_logprobs.append(float(seg.avg_logprob))
+        # 3) ulteriore segnale: no_speech_prob alto => bassa confidenza
+        if getattr(seg, "no_speech_prob", None) is not None:
+            no_speech.append(float(seg.no_speech_prob))
+
+    if word_probs:
+        return float(mean(word_probs))
+
+    if avg_logprobs:
+        return float(mean(_sigmoid(x) for x in avg_logprobs))
+
+    if no_speech:
+        return float(max(0.0, 1.0 - mean(no_speech)))
+
+    return 0.5  # neutrale se non abbiamo nulla


### PR DESCRIPTION
## Descrizione

Questa pull request introduce miglioramenti significativi al flusso di lavoro della trascrizione audio, concentrandosi su **punteggio di confidenza**, **comunicazione client-server** e **flessibilità di configurazione**.

---

### 1. Confidenza ASR e logica di trascrizione
- **Nuovo calcolo della confidenza** nel servizio ASR (`transcribe_wav`), basato su:
  - Probabilità delle parole
  - Logprobs dei segmenti
  - Probabilità della lingua
- Restituzione del **punteggio di confidenza** insieme alla trascrizione.
- Aggiornamento dell’endpoint server in `transcribe.py`:
  - Se **confidenza < soglia configurabile** → `status="clarify"` per chiedere di ripetere/precisare.
  - Se **confidenza ≥ soglia** → `status="ok"`.

---

### 2. Comunicazione client-server e refactoring
- **Refactoring lato client**:
  - Creata nuova funzione `send_audio_and_get_result` in `request_handler.py` per gestire l’upload dell’audio.
  - L’handler dell’evento di wake word ora:
    - Esegue un ciclo di invio finché la confidenza è bassa.
    - Chiede all’utente di ripetere l’audio quando necessario.

---

### 3. Miglioramenti di configurazione
- Nuove opzioni in `Config`:
  - `ASR_CONF_THRESHOLD` → soglia minima di confidenza.
  - `ASR_MIN_WORDS` → numero minimo di parole richieste.
- Permettono **maggiore robustezza e flessibilità** lato server.

---

### 4. Modifiche varie
- Rimosso caricamento `dotenv` non utilizzato in `wake.py`.
- Impostato modello ASR predefinito su **"medium"**.


**Change references:**  
[[1]](diffhunk://#diff-f2dd8b29e46424dad1b01142ab3203a8a5acd2a8f9bc1856b415f1b06c394b30R2-R83) [[2]](diffhunk://#diff-329182ec019849910ab7de4317c29ca4c9cc7bfa5a88c57c13857bc9bdb7411eL27-R57) [[3]](diffhunk://#diff-92d8321dcce2cdc4ee73ec09ed0efabb1d509a718fbf9b10590d677e8e7189d1R2-R35) [[4]](diffhunk://#diff-c57de0e25eaf1f85d6c2c02a9ad49d66659c86305408687d03873377bb614037R1-R12) [[5]](diffhunk://#diff-788f2939de36376a9e5c6917383c7e204367c05d11ad2fdc49d292b28ef1255bR17-R18) [[6]](diffhunk://#diff-62c292ff5a7e54bf283309374c85ec0d5ab38b775d4aaa9b04a7f9038842badaL2-L8)